### PR TITLE
Serve: query params in event.$query

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -113,6 +113,15 @@ module.exports.run = function(JAWS, init, prefix, port) {
                 }
               }
 
+              for( prop in req.query ) {
+                if( req.query.hasOwnProperty( prop ) ){
+                  if( event.$query == null ){
+                    event.$query = {};
+                  }
+                  event.$query[ prop ] = req.query[ prop ];
+                }
+              }
+
               if( !handler ) {
                 try {
                   handler = require( handlerPath )[handlerParts[1]];

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -115,10 +115,7 @@ module.exports.run = function(JAWS, init, prefix, port) {
 
               for( prop in req.query ) {
                 if( req.query.hasOwnProperty( prop ) ){
-                  if( event.$query == null ){
-                    event.$query = {};
-                  }
-                  event.$query[ prop ] = req.query[ prop ];
+                  event[ prop ] = req.query[ prop ];
                 }
               }
 


### PR DESCRIPTION
`jaws serve` puts query params to event.$query
This is particularly handy for GET lambda endpoints.

To make API GW work this way use integration request template:

``` javascript
{
    #foreach($k in $input.params().querystring.keySet())
    "$k":"$util.escapeJavaScript($util.urlDecode($input.params($k)))"#if($foreach.hasNext),#end
    #end
}
```

(put this to RequestTemplates.application/json in the awsm.json)
